### PR TITLE
Add :fips option to start the server

### DIFF
--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -71,6 +71,8 @@ module Gemstash
     desc "start", "Starts your gemstash server"
     method_option :daemonize, :type => :boolean, :default => true, :desc =>
       "Daemonize the server"
+    method_option :fips, :type => :boolean, :default => false, :desc =>
+      "Choose crypto compliant with FIPS"
     method_option :config_file, :type => :string, :desc =>
       "Config file to load when starting"
     def start

--- a/lib/gemstash/cli/start.rb
+++ b/lib/gemstash/cli/start.rb
@@ -10,6 +10,7 @@ module Gemstash
         prepare
         setup_logging
         store_daemonized
+        store_fips
         @cli.say("Starting gemstash!", :green)
         Puma::CLI.new(args, Gemstash::Logging::StreamLogger.puma_events).run
       end
@@ -25,8 +26,16 @@ module Gemstash
         Gemstash::Env.daemonized = daemonize?
       end
 
+      def store_fips
+        Gemstash::Env.current.config[:fips] = fips?
+      end
+
       def daemonize?
         @cli.options[:daemonize]
+      end
+
+      def fips?
+        @cli.options[:fips]
       end
 
       def puma_config

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -6,6 +6,7 @@ module Gemstash
   class Configuration
     DEFAULTS = {
       cache_type: "memory",
+      fips: false,
       base_path: File.expand_path("~/.gemstash"),
       db_adapter: "sqlite3",
       bind: "tcp://0.0.0.0:9292",
@@ -63,6 +64,14 @@ module Gemstash
         { max_connections: (self[:puma_workers] * self[:puma_threads]) + 1 }.merge(self[:db_connection_options])
       else
         raise "Unsupported DB adapter: '#{self[:db_adapter]}'"
+      end
+    end
+
+    def digest_class
+      @digest_class ||= if self[:fips]
+        Digest::SHA256
+      else
+        Digest::MD5
       end
     end
 

--- a/lib/gemstash/storage.rb
+++ b/lib/gemstash/storage.rb
@@ -114,7 +114,7 @@ module Gemstash
       trie_parents = safe_name[0...3].downcase.split("")
       # The digest is included in case the name differs only by case
       # Some file systems are case insensitive, so such collisions will be a problem
-      digest = Digest::SHA256.hexdigest(@name)
+      digest = Gemstash::Env.current.config.digest_class.hexdigest(@name)
       child_folder = "#{safe_name}-#{digest}"
       @folder = File.join(@base_path, *trie_parents, child_folder)
       @properties = nil

--- a/lib/gemstash/storage.rb
+++ b/lib/gemstash/storage.rb
@@ -114,7 +114,7 @@ module Gemstash
       trie_parents = safe_name[0...3].downcase.split("")
       # The digest is included in case the name differs only by case
       # Some file systems are case insensitive, so such collisions will be a problem
-      digest = Digest::MD5.hexdigest(@name)
+      digest = Digest::SHA256.hexdigest(@name)
       child_folder = "#{safe_name}-#{digest}"
       @folder = File.join(@base_path, *trie_parents, child_folder)
       @properties = nil

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -40,7 +40,7 @@ module Gemstash
   private
 
     def hash
-      Digest::SHA256.hexdigest(to_s)
+      Gemstash::Env.current.config.digest_class.hexdigest(to_s)
     end
 
     #:nodoc:

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -40,7 +40,7 @@ module Gemstash
   private
 
     def hash
-      Digest::MD5.hexdigest(to_s)
+      Digest::SHA256.hexdigest(to_s)
     end
 
     #:nodoc:


### PR DESCRIPTION
This PR adds a `:fips` option to the `start` CLI command.

It picks the class to do digest with using this setting, which can also be configured in the Configuration.